### PR TITLE
[fix] modify release aab file path

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -16,7 +16,7 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: all-the-time
-          file: app/build/outputs/apk/release/app-release.apk
+          file: app/release/app-release.aab
           releaseNotes: |
             ${{ github.event.pull_request.title }}
             ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## 설명
```kotlin
File app/build/outputs/apk/release/app-release.apk does not exist: verify that file points to a binary
```
- 잘못된 release 파일 경로 수정